### PR TITLE
Adding test runner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ elm-stuff/
 repl-temp-*
 lib/index.js
 node_modules/
+tests/**/elm-package.json

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "run-elm": "lib/index.js"
   },
   "scripts": {
+    "pretest": "npm run build",
+    "test": "node tests/run-tests.js",
     "build": "babel index.js --out-dir lib",
     "prepublish": "npm run build"
   },

--- a/tests/hello-world/Main.elm
+++ b/tests/hello-world/Main.elm
@@ -1,0 +1,6 @@
+module Main exposing (..)
+
+
+output : String
+output =
+    "Hello World!"

--- a/tests/hello-world/output.txt
+++ b/tests/hello-world/output.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,57 @@
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+const path = require('path');
+const inspect = require('util').inspect;
+
+const runElmPath = path.resolve(
+  path.join(__dirname, '..', 'lib', 'index.js'));
+
+const baseDir = path.resolve(
+  path.join(__dirname, '..', 'tests'));
+
+const testDirs = fs
+  .readdirSync(baseDir)
+  .map(filename => ({
+    name: filename,
+    path: path.join(baseDir, filename),
+  }))
+  .filter(test => fs.statSync(test.path).isDirectory());
+
+const results = testDirs.map((test) => {
+  const mainFile = path.join(test.path, 'Main.elm');
+  const expectedOutput = fs.readFileSync(path.join(test.path, 'output.txt'));
+  let actualOutput;
+  try {
+    actualOutput = execSync(`${runElmPath} ${mainFile}`);
+  } catch (err) {
+    return {
+      pass: false,
+      reason: `${test.name} failed: Process timeout or non-zero exit code
+  ${err}
+`,
+    };
+  }
+  if (actualOutput.toString() !== expectedOutput.toString()) {
+    return {
+      pass: false,
+      reason: `${test.name} failed: Output mismatch
+  Expected: ${inspect(expectedOutput.toString())}
+  Actual:   ${inspect(actualOutput.toString())}
+`,
+    };
+  }
+  return { pass: true };
+});
+
+const failures = results
+  .filter(r => !r.pass)
+  .map(r => r.reason);
+
+console.log(failures.join('\n'));
+
+if (failures.length > 0) {
+  console.log(`${failures.length} of ${results.length} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`All ${results.length} test(s) passed`);
+}


### PR DESCRIPTION
Exercises as a command-line tool

Example output from a test failure:

```
> $ npm test

> run-elm@1.0.1 pretest /Users/kevin/bc/run-elm
> npm run build


> run-elm@1.0.1 build /Users/kevin/bc/run-elm
> babel index.js --out-dir lib

index.js -> lib/index.js

> run-elm@1.0.1 test /Users/kevin/bc/run-elm
> node tests/run-tests.js

hello-world failed: Output mismatch
  Expected: 'Hellso World!\n'
  Actual:   'Hello World!\n'

1 of 1 test(s) failed
npm ERR! Test failed.  See above for more details.
```

I plan to add argument support, and use this to add more tests.