### PR TITLE
Test multiple conditions per project and errors

### DIFF
--- a/test/integration/case-projects/args/test-config.js
+++ b/test/integration/case-projects/args/test-config.js
@@ -1,4 +1,13 @@
-module.exports = {
+module.exports = [{
+  args: ['Main.elm'],
+  expectedStdout: '!\n',
+}, {
+  args: ['Main.elm', 'hello'],
+  expectedStdout: 'hello!\n',
+}, {
   args: ['Main.elm', 'hello', 'world'],
   expectedStdout: 'hello-world!\n',
-};
+}, {
+  args: ['Main.elm', 'hello', 'world', '42'],
+  expectedStdout: 'hello-world-42!\n',
+}];

--- a/test/integration/case-projects/basic/test-config.js
+++ b/test/integration/case-projects/basic/test-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = [{
   args: ['Main.elm'],
   expectedStdout: 'static output\n',
-};
+}];

--- a/test/integration/case-projects/basic/test-config.js
+++ b/test/integration/case-projects/basic/test-config.js
@@ -3,6 +3,10 @@ module.exports = [{
   args: ['Main.elm'],
   expectedStdout: 'static output\n',
 }, {
+  title: 'superfluous arguments',
+  args: ['Main.elm', 'superfluous', 'arguments'],
+  expectedStdout: 'static output\n',
+}, {
   title: 'non-existing module',
   args: ['NonExistingModule.elm'],
   expectedExitCode: 1,

--- a/test/integration/case-projects/basic/test-config.js
+++ b/test/integration/case-projects/basic/test-config.js
@@ -1,4 +1,10 @@
 module.exports = [{
+  title: 'minimal example',
   args: ['Main.elm'],
   expectedStdout: 'static output\n',
+}, {
+  title: 'non-existing module',
+  args: ['NonExistingModule.elm'],
+  expectedExitCode: 1,
+  expectedStderr: ({ projectDir }) => `Error: File '${projectDir}/NonExistingModule.elm' does not exist\n`,
 }];

--- a/test/integration/case-projects/custom-constant/test-config.js
+++ b/test/integration/case-projects/custom-constant/test-config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  args: ['--output-name=customConstant', 'Main.elm'],
-  expectedStdout: 'static output from custom constant\n',
-};

--- a/test/integration/case-projects/custom-function/test-config.js
+++ b/test/integration/case-projects/custom-function/test-config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  args: ['--output-name=customFunction', 'Main.elm', 'forty', 'two'],
-  expectedStdout: 'static output from forty two\n',
-};

--- a/test/integration/case-projects/custom-output/CustomOutputWithConstant.elm
+++ b/test/integration/case-projects/custom-output/CustomOutputWithConstant.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module CustomOutputWithConstant exposing (..)
 
 
 customConstant : String

--- a/test/integration/case-projects/custom-output/CustomOutputWithFunction.elm
+++ b/test/integration/case-projects/custom-output/CustomOutputWithFunction.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module CustomOutputWithFunction exposing (..)
 
 
 output : String

--- a/test/integration/case-projects/custom-output/test-config.js
+++ b/test/integration/case-projects/custom-output/test-config.js
@@ -1,0 +1,9 @@
+module.exports = [{
+  title: 'constant',
+  args: ['--output-name=customConstant', 'CustomOutputWithConstant.elm'],
+  expectedStdout: 'static output from custom constant\n',
+}, {
+  title: 'function',
+  args: ['--output-name=customFunction', 'CustomOutputWithFunction.elm', 'forty', 'two'],
+  expectedStdout: 'static output from forty two\n',
+}];

--- a/test/integration/case-projects/long-output/test-config.js
+++ b/test/integration/case-projects/long-output/test-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = [{
   args: ['Main.elm'],
   expectedStdout: () => 'static output\n'.repeat(1000000),
-};
+}];

--- a/test/integration/case-projects/subdirectory-no-root/test-config.js
+++ b/test/integration/case-projects/subdirectory-no-root/test-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = [{
   args: ['--project-dir=.', 'src/Main.elm'],
   expectedStdout: 'static output from subdirectory with dependencies no root\n',
-};
+}];

--- a/test/integration/case-projects/subdirectory-with-dependencies/test-config.js
+++ b/test/integration/case-projects/subdirectory-with-dependencies/test-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = [{
   args: ['--project-dir=.', 'src/Main.elm'],
   expectedStdout: 'static output from subdirectory with dependencies\n',
-};
+}];

--- a/test/integration/case-projects/subdirectory/test-config.js
+++ b/test/integration/case-projects/subdirectory/test-config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = [{
   args: ['--project-dir=.', 'src/Main.elm'],
   expectedStdout: 'static output from subdirectory\n',
-};
+}];

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -12,27 +12,30 @@ describe('run-elm', () => {
 
   projectDirs.forEach((projectDir) => {
     const projectName = basename(projectDir);
+    const conditions = require(resolve(projectDir, 'test-config.js'));
+    conditions.forEach(({ args, expectedStdout: rawExpectedStdout, title: rawTitle }, i) => {
+      const autoTitle = conditions.length > 1 ? `condition ${i}` : '';
+      const title = rawTitle || autoTitle;
+      test(`correctly works for case project \`${projectName}\`${title ? ` (${title})` : ''}`, async () => {
+        const expectedStdout = typeof (rawExpectedStdout) === 'function'
+          ? rawExpectedStdout()
+          : rawExpectedStdout;
 
-    test(`correctly works for case project \`${projectName}\``, async () => {
-      const { args, expectedStdout: rawExpectedStdout } = require(resolve(projectDir, 'test-config.js'));
-      const expectedStdout = typeof (rawExpectedStdout) === 'function'
-        ? rawExpectedStdout()
-        : rawExpectedStdout;
-
-      let result;
-      try {
-        result = await execFile(runElmPath, args, {
-          cwd: projectDir,
-          maxBuffer: 1024 * 1024 * 100
-        });
-      } catch (e) {
-        const { code, stderr, message } = e;
-        const details = stderr || message;
-        throw new Error(`process timeout or non-zero exit code ${code}${details ? `: ${details}` : ''}`);
-      }
-      expect(result.stdout.length).toEqual(expectedStdout.length);
-      expect(result.stdout).toEqual(expectedStdout);
-      expect(result.stderr).toEqual('');
-    }, 30000);
+        let result;
+        try {
+          result = await execFile(runElmPath, args, {
+            cwd: projectDir,
+            maxBuffer: 1024 * 1024 * 100
+          });
+        } catch (e) {
+          const { code, stderr, message } = e;
+          const details = stderr || message;
+          throw new Error(`process timeout or non-zero exit code ${code}${details ? `: ${details}` : ''}`);
+        }
+        expect(result.stdout.length).toEqual(expectedStdout.length);
+        expect(result.stdout).toEqual(expectedStdout);
+        expect(result.stderr).toEqual('');
+      }, 30000);
+    });
   });
 });


### PR DESCRIPTION
This PR makes it possible to run each case project under multiple conditions, which makes it easier to be scrupulous. It also allows for error checking, which means that a failed `run-elm` does not necessary fail a test. There are additional checks for `expectedExitCode` and `expectedStderr`.

Jest output looks like this now:

<img width="620" alt="screen shot 2018-03-02 at 17 48 40" src="https://user-images.githubusercontent.com/608862/36913470-fa98035c-1e41-11e8-8c4d-edd7001c6851.png">
